### PR TITLE
Blacklist AWS::Cognito

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "2.11.8"
 
-val circeVersion = "0.7.0-M1"
+val circeVersion = "0.8.0"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",

--- a/expand/src/main/scala/com/timeout/scalacloudformation/AWSResources.scala
+++ b/expand/src/main/scala/com/timeout/scalacloudformation/AWSResources.scala
@@ -14,6 +14,6 @@ object AWSResources {
 
   case class Tag(key: String, value: String)
 
-  @CloudformationGen
+  @CloudformationGen("AWS::Cognito")
   object Gen
 }

--- a/expand/src/main/scala/com/timeout/scalacloudformation/AWSResources.scala
+++ b/expand/src/main/scala/com/timeout/scalacloudformation/AWSResources.scala
@@ -14,6 +14,6 @@ object AWSResources {
 
   case class Tag(key: String, value: String)
 
-  @CloudformationGen("AWS::Cognito")
+  @CloudformationGen()
   object Gen
 }

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -1,4 +1,4 @@
-val circeVersion = "0.7.0-M1"
+val circeVersion = "0.8.0"
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value

--- a/macros/src/main/scala/com/timeout/CloudformationGen.scala
+++ b/macros/src/main/scala/com/timeout/CloudformationGen.scala
@@ -6,17 +6,7 @@ import scala.meta._
 
 class CloudformationGen extends scala.annotation.StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
-
-    val prefixes = this match {
-      case q"new $_($arg)" =>
-        val prefixes = arg.collect { case Lit(s: String) => s }.toSet
-        System.err.println(s"Excluding AWS resource prefixes: ${prefixes.mkString(", ")}")
-        prefixes
-      case _ =>
-        Set.empty[String]
-    }
-
-    val gen = new CodeGen(Config(excludePrefixes = prefixes))
+    val gen = new CodeGen(Config(excludePrefixes = Set("AWS::Cognito")))
 
     defn match {
       case q"object $_ {..$_}" =>

--- a/macros/src/main/scala/com/timeout/CloudformationGen.scala
+++ b/macros/src/main/scala/com/timeout/CloudformationGen.scala
@@ -1,104 +1,28 @@
 package com.timeout
 
-import scala.meta.Defn
-import scala.meta.Term
+import com.timeout.CodeGen.Config
+
 import scala.meta._
 
-object CloudformationGen {
-  def mapPrimitiveType(primitiveType: PrimitiveType): Type.Name = primitiveType match {
-    case PrimitiveType.String => Type.Name("String")
-    case PrimitiveType.Long => Type.Name("Long")
-    case PrimitiveType.Integer => Type.Name("Int")
-    case PrimitiveType.Double => Type.Name("Double")
-    case PrimitiveType.Boolean => Type.Name("Boolean")
-    case PrimitiveType.Timestamp => Type.Name("java.time.ZonedDateTime")
-    case PrimitiveType.Json => Type.Name("io.circe.Json")
-  }
-
-  def mapAwsType(namespace: Option[Namespace])(awsType: AwsType): Type = awsType match {
-    case p: PrimitiveType =>
-      mapPrimitiveType(p)
-    case TagType =>
-      Type.Name("Tag")
-    case PropertyTypeRef(_, name) =>
-      val fqn = namespace.fold(name) { ns: String => s"$ns.$name" }
-      Type.Name(fqn)
-    case ListType(itemType) =>
-      val typeName = mapAwsType(namespace)(itemType)
-      t"List[$typeName]"
-    case MapType(itemType) =>
-      val typeName = mapAwsType(namespace)(itemType)
-      t"Map[String, $typeName]"
-  }
-
-  def normalize(str: String): String =
-    str.filter(_.isLetterOrDigit)
-
-  // Contains custom properties and generic derivations
-  val objectStats: List[Defn.Object] =
-    SpecsParser.propertyTypes.toList.map { case (namespace, props) =>
-      val objectName = Term.Name(normalize(namespace))
-      val typeName = Type.Name(normalize(namespace))
-
-      val classDefs = props.map { prop =>
-        val className = Type.Name(prop.name)
-
-        val properties = prop.properties.map(mkField(_, None))
-
-        q"case class $className (..$properties)"
-      }
-
-      val generic =
-        q"implicit val generic = LabelledGeneric[$typeName]"
-
-      q"""object $objectName {
-            ..$classDefs
-            $generic
-         }
-       """
-    }
-
-  val classStats: List[Defn] =
-    SpecsParser.resourceTypes.map { rt =>
-      val normalized = normalize(rt.fqn)
-      val typeName = Type.Name(normalized)
-
-      val namespace = normalize(rt.fqn.takeWhile(_ != "."))
-      val logicalIdProp: Term.Param = param"logicalId: String"
-      val properties = logicalIdProp :: rt.properties.map(mkField(_, Some(namespace)))
-      val fqn = Term.Name("\"" + rt.fqn + "\"")
-
-      val declaration = q"""case class $typeName (..$properties) extends Resource {
-            override def fqn: String = $fqn
-         }
-       """
-
-
-       declaration
-    }
-
-  private def mkField(property: Property, namespace: Option[Namespace]): Term.Param = {
-    val paramName = Term.Name(property.name)
-
-    val typeName = mapAwsType(namespace)(property.awsType)
-
-    if (property.required) {
-      param"$paramName: CfExp[$typeName]"
-    } else {
-      param"$paramName: Option[CfExp[$typeName]]"
-    }
-  }
-}
-import CloudformationGen._
-
 class CloudformationGen extends scala.annotation.StaticAnnotation {
-
   inline def apply(defn: Any): Any = meta {
+
+    val prefixes = this match {
+      case q"new $_($arg)" =>
+        val prefixes = arg.collect { case Lit(s: String) => s }.toSet
+        System.err.println(s"Excluding AWS resource prefixes: ${prefixes.mkString(", ")}")
+        prefixes
+      case _ =>
+        Set.empty[String]
+    }
+
+    val gen = new CodeGen(Config(excludePrefixes = prefixes))
+
     defn match {
       case q"object $_ {..$_}" =>
-        q"..${objectStats ++ classStats}"
+        q"..${gen.objectStats ++ gen.classStats}"
       case _ =>
-        abort("@cf-resources must be used on an object")
+        abort("@CloudformationGen must be used on an object")
     }
   }
 }

--- a/macros/src/main/scala/com/timeout/CodeGen.scala
+++ b/macros/src/main/scala/com/timeout/CodeGen.scala
@@ -1,0 +1,92 @@
+package com.timeout
+
+import scala.meta._
+
+object CodeGen {
+  case class Config(excludePrefixes: Set[String] = Set.empty)
+}
+
+class CodeGen(conf: CodeGen.Config) {
+  def mapPrimitiveType(primitiveType: PrimitiveType): Type.Name = primitiveType match {
+    case PrimitiveType.String => Type.Name("String")
+    case PrimitiveType.Long => Type.Name("Long")
+    case PrimitiveType.Integer => Type.Name("Int")
+    case PrimitiveType.Double => Type.Name("Double")
+    case PrimitiveType.Boolean => Type.Name("Boolean")
+    case PrimitiveType.Timestamp => Type.Name("java.time.ZonedDateTime")
+    case PrimitiveType.Json => Type.Name("io.circe.Json")
+  }
+
+  def mapAwsType(namespace: Option[Namespace])(awsType: AwsType): Type = awsType match {
+    case p: PrimitiveType =>
+      mapPrimitiveType(p)
+    case TagType =>
+      Type.Name("Tag")
+    case PropertyTypeRef(_, name) =>
+      val fqn = namespace.fold(name) { ns: String => s"$ns.$name" }
+      Type.Name(fqn)
+    case ListType(itemType) =>
+      val typeName = mapAwsType(namespace)(itemType)
+      t"List[$typeName]"
+    case MapType(itemType) =>
+      val typeName = mapAwsType(namespace)(itemType)
+      t"Map[String, $typeName]"
+  }
+
+  def normalize(str: String): String =
+    str.filter(_.isLetterOrDigit)
+
+  // Contains custom properties and generic derivations
+  val objectStats: List[Defn.Object] =
+    SpecsParser.propertyTypes(conf.excludePrefixes).toList.map { case (namespace, props) =>
+      val objectName = Term.Name(normalize(namespace))
+      val typeName = Type.Name(normalize(namespace))
+
+      val classDefs = props.map { prop =>
+        val className = Type.Name(prop.name)
+
+        val properties = prop.properties.map(mkField(_, None))
+
+        q"case class $className (..$properties)"
+      }
+
+      val generic =
+        q"implicit val generic = LabelledGeneric[$typeName]"
+
+      q"""object $objectName {
+            ..$classDefs
+            $generic
+         }
+       """
+    }
+
+  val classStats: List[Defn] =
+    SpecsParser.resourceTypes(conf.excludePrefixes).map { rt =>
+      val normalized = normalize(rt.fqn)
+      val typeName = Type.Name(normalized)
+
+      val namespace = normalize(rt.fqn.takeWhile(_ != "."))
+      val logicalIdProp: Term.Param = param"logicalId: String"
+      val properties = logicalIdProp :: rt.properties.map(mkField(_, Some(namespace)))
+      val fqn = Term.Name("\"" + rt.fqn + "\"")
+
+      val declaration = q"""case class $typeName (..$properties) extends Resource {
+            override def fqn: String = $fqn
+         }
+       """
+
+      declaration
+    }
+
+  private def mkField(property: Property, namespace: Option[Namespace]): Term.Param = {
+    val paramName = Term.Name(property.name)
+
+    val typeName = mapAwsType(namespace)(property.awsType)
+
+    if (property.required) {
+      param"$paramName: CfExp[$typeName]"
+    } else {
+      param"$paramName: Option[CfExp[$typeName]]"
+    }
+  }
+}


### PR DESCRIPTION
Looks like the current version of the Cloud Formation spec file is not well formatted, as a number of fields/resources in the AWS::Cognito package use "type" instead of "primitiveType" specifying Json as a value:

```json
    "AWS::Cognito::IdentityPoolRoleAttachment": {                                                                                                                                                          
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypoolroleattachment.html",                                                               
      "Properties": {                                                                                                                                                                                      
        "RoleMappings": {                                                                                                                                                                                  
          "Type": "Json",                                                                                                                                                                                  
          "Required": false,                                                                                                                                                                               
          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypoolroleattachment.html#cfn-cognito-identitypoolroleattachment-rolemappings",       
          "UpdateType": "Mutable"                                                                                                                                                                          
        },                                                                                                                                                                                                 
        "IdentityPoolId": {                                                                                                                                                                                
          "Required": true,                                                                                                                                                                                
          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypoolroleattachment.html#cfn-cognito-identitypoolroleattachment-identitypoolid",     
          "PrimitiveType": "String",                                                                                                                                                                       
          "UpdateType": "Immutable"                                                                                                                                                                        
        },                                                                                                                                                                                                 
        "Roles": {                                                                                                                                                                                         
          "Type": "Json",                                                                                                                                                                                  
          "Required": false,                                                                                                                                                                               
          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypoolroleattachment.html#cfn-cognito-identitypoolroleattachment-roles",              
          "UpdateType": "Mutable"                                                                                                                                                                          
        }                                                                                                                                                                                                  
      }                                                                                                                                                                                                    
    }
```
Instead of trying to handle in the macro an invalid specification, this PR extends the annotation with the option to inject one or more prefixes to exclude. 